### PR TITLE
Fix constant definitions and order logging

### DIFF
--- a/Experts/Aegis/includes/aegis_constants.mqh
+++ b/Experts/Aegis/includes/aegis_constants.mqh
@@ -1,14 +1,14 @@
 #pragma once
 // Централизованные константы и параметры (Документ: Финальное ТЗ v4.0)
-#define AEG_MAX_SYMS 4
-#define AEG_MAX_LVLS 5
+const int    AEG_MAX_SYMS = 4;
+const int    AEG_MAX_LVLS = 5;
 
 // Базовые символы (Документ: "Что делает Эгида сейчас")
-string AEG_SYMS[AEG_MAX_SYMS] = {"BTCUSD","LTCUSD","BCHUSD","ETHUSD"};
+const string AEG_SYMS[AEG_MAX_SYMS] = {"BTCUSD","LTCUSD","BCHUSD","ETHUSD"};
 
 // Весовая модель сеток 1:1:2:4 (инвариант — Финальное ТЗ)
-double AEG_WEIGHTS[4] = {1,1,2,4};
-double AEG_WEIGHTS_SUM = 8.0;
+const double AEG_WEIGHTS[AEG_MAX_SYMS] = {1.0,1.0,2.0,4.0};
+const double AEG_WEIGHTS_SUM = 8.0;
 
 // Порог маржинальной проекции (%) — временно фикс
 double AEG_MARGIN_PCT = 45.0;

--- a/Experts/SuhabFiboTrader_v59_fixed_prompt23_trade (2).mq5
+++ b/Experts/SuhabFiboTrader_v59_fixed_prompt23_trade (2).mq5
@@ -74,10 +74,20 @@ int OnInit()
    PrintFormat("Всего ордеров: %d", total_ord);
    for(int j=0; j<total_ord; j++)
      {
-      if(order.Select(j,SELECT_BY_POS,MODE_TRADES))
+      ulong ticket = OrderGetTicket(j);
+      if(ticket==0)
+        {
+         PrintFormat("ORD[%d]: не удалось получить тикет (err=%d)", j, GetLastError());
+         continue;
+        }
+      if(order.Select(ticket))
         {
          PrintFormat("ORD[%d]: Тикет=%I64d  Символ=%s  Объем=%.2f  Цена=%.5f",
                      j, order.Ticket(), order.Symbol(), order.VolumeInitial(), order.PriceOpen());
+        }
+      else
+        {
+         PrintFormat("ORD[%d]: Select(%I64d) завершился ошибкой (err=%d)", j, ticket, GetLastError());
         }
      }
 


### PR DESCRIPTION
## Summary
- replace macro-based limits in `aegis_constants.mqh` with typed `const` definitions to avoid implicit conversions
- update the prompt23 trade sample to fetch order tickets explicitly before calling `COrderInfo::Select`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3af690698832aad48b672be70eea0