### PR TITLE
Add version logging banner to Aegis S EAs

### DIFF
--- a/Experts/Aegis/AegisEA_S5_RU_MIN_RollingPersistFSM_Version2.mq5
+++ b/Experts/Aegis/AegisEA_S5_RU_MIN_RollingPersistFSM_Version2.mq5
@@ -18,6 +18,12 @@
 
 #include "includes/aegis_core.mqh"
 
+#define AE_VIS_VERSION "S5-RU-MIN-1.61"
+void Aegis_LogVersion()
+{
+   Print("[Aegis] ", __FILE__, " v", AE_VIS_VERSION, " build ", __DATE__, " ", __TIME__);
+}
+
 ////////////////////////////////////////////////////////////
 // CONSTANTS AND VARIABLES (needed for extracted modules)
 ////////////////////////////////////////////////////////////
@@ -581,6 +587,7 @@ void WriteSummary()
 ////////////////////////////////////////////////////////////
 int OnInit()
 {
+   Aegis_LogVersion();
    g_symbol=Symbol();
    g_NextAvgIndex=(NextAvgIndexInit>0?NextAvgIndexInit:1);
    PrintFormat("[Aegis][S5] Init %s (idx=%d)", g_symbol, g_NextAvgIndex);

--- a/Experts/Aegis/experts/AegisEA_S5_RU_MIN_RollingPersistFSM_Version2.mq5
+++ b/Experts/Aegis/experts/AegisEA_S5_RU_MIN_RollingPersistFSM_Version2.mq5
@@ -16,6 +16,12 @@
 #property version "1.61"
 #property description "Aegis S5 RU MIN: rolling log + state durations + scenarios (DRY, fix trim)"
 
+#define AE_VIS_VERSION "S5-RU-MIN-1.61"
+void Aegis_LogVersion()
+{
+   Print("[Aegis] ", __FILE__, " v", AE_VIS_VERSION, " build ", __DATE__, " ", __TIME__);
+}
+
 ////////////////////////////////////////////////////////////
 // INPUTS
 ////////////////////////////////////////////////////////////
@@ -564,6 +570,7 @@ void WriteSummary()
 ////////////////////////////////////////////////////////////
 int OnInit()
 {
+   Aegis_LogVersion();
    g_symbol=Symbol();
    g_NextAvgIndex=(NextAvgIndexInit>0?NextAvgIndexInit:1);
    PrintFormat("[Aegis][S5] Init %s (idx=%d)", g_symbol, g_NextAvgIndex);

--- a/Experts/Aegis/experts/Aegis_S_Base.mq5
+++ b/Experts/Aegis/experts/Aegis_S_Base.mq5
@@ -4,7 +4,14 @@
 
 #include "..\\includes\\aegis_core.mqh"
 
+#define AE_VIS_VERSION "S-BASE-5.1.0"
+void Aegis_LogVersion()
+{
+  Print("[Aegis] ", __FILE__, " v", AE_VIS_VERSION, " build ", __DATE__, " ", __TIME__);
+}
+
 int OnInit(){
+  Aegis_LogVersion();
   AEG_Log("[INIT] Aegis Base modular start");
   for(int i=0;i<AEG_MAX_SYMS;i++) AEG_Phases[i]=AEG_PH_IDLE;
   return(INIT_SUCCEEDED);


### PR DESCRIPTION
## Summary
- add AE_VIS_VERSION banners and logging helpers to the S5 rolling persist EA sources
- log the build banner during initialization of the modular base EA

## Testing
- not run (MetaTrader tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3af690698832aad48b672be70eea0