### PR TITLE
Fix weight constants to avoid data loss warning

### DIFF
--- a/Experts/Aegis/includes/aegis_constants.mqh
+++ b/Experts/Aegis/includes/aegis_constants.mqh
@@ -7,8 +7,8 @@
 string AEG_SYMS[AEG_MAX_SYMS] = {"BTCUSD","LTCUSD","BCHUSD","ETHUSD"};
 
 // Весовая модель сеток 1:1:2:4 (инвариант — Финальное ТЗ)
-double AEG_WEIGHTS[4] = {1,1,2,4};
-double AEG_WEIGHTS_SUM = 8.0;
+const double AEG_WEIGHTS[4] = {1.0,1.0,2.0,4.0};
+const double AEG_WEIGHTS_SUM = 8.0;
 
 // Порог маржинальной проекции (%) — временно фикс
 double AEG_MARGIN_PCT = 45.0;


### PR DESCRIPTION
## Summary
- update the weight constants in `aegis_constants.mqh` to use double literals and mark them const to prevent type-conversion warnings during compilation

## Testing
- not run (MetaTrader compiler not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e3af690698832aad48b672be70eea0